### PR TITLE
Loader API option 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.log
 
 # Editors
+*~
 .settings/
 .project
 .classpath

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -48,5 +48,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <docfilessubdirs>true</docfilessubdirs>
+                    <doclint>all</doclint>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/api/src/main/java/jakarta/config/ConfigException.java
+++ b/api/src/main/java/jakarta/config/ConfigException.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jakarta.config;
+
+/**
+ * A {@link RuntimeException} thrown when a problem is encountered in
+ * an implementation of the Jakarta Config specfication.
+ */
+public class ConfigException extends RuntimeException {
+
+    /**
+     * Creates a new {@link ConfigException}.
+     */
+    public ConfigException() {
+        super();
+    }
+
+    /**
+     * Creates a new {@link ConfigException}.
+     *
+     * @param message a detail message; may be {@code null}
+     */
+    public ConfigException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new {@link ConfigException}.
+     *
+     * @param cause the {@link Throwable} responsible for this {@link
+     * ConfigException}'s existence; may be {@code null}
+     */
+    public ConfigException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new {@link ConfigException}.
+     *
+     * @param message a detail message; may be {@code null}
+     *
+     * @param cause the {@link Throwable} responsible for this {@link
+     * ConfigException}'s existence; may be {@code null}
+     */
+    public ConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/api/src/main/java/jakarta/config/Loader.java
+++ b/api/src/main/java/jakarta/config/Loader.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jakarta.config;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+/**
+ * A loader of configuration-related objects.
+ *
+ * <p>Sample usage:</p>
+ *
+ * <blockquote><pre>{@linkplain Loader Loader} loader = {@linkplain Loader Loader}.{@linkplain Loader#bootstrap() bootstrap()};
+ *MyConfigurationRelatedObject object = null;
+ *try {
+ *  object = loader.{@linkplain #load(Request) load}({@linkplain Request Request}.{@linkplain Request#builder(Class) builder}(MyConfigurationRelatedObject.class){@linkplain Request.Builder#build() build()});
+ *} catch ({@linkplain NoSuchObjectException} noSuchObjectException) {
+ *  // object is <a href="doc-files/terminology.html#absent">absent</a>
+ *} catch ({@linkplain ConfigException} configException) {
+ *  // a {@linkplain #load(Request) loading}-related error occurred
+ *}</pre></blockquote>
+ *
+ * @see #bootstrap()
+ *
+ * @see #bootstrap(ClassLoader)
+ *
+ * @see #load(Request)
+ *
+ * @see <a href="doc-files/terminology.html">Terminology</a>
+ */
+public interface Loader {
+
+    /**
+     * Loads a configuration-related object <a
+     * href="doc-files/terminology.html#suitability"><em>suitable</em></a>
+     * for the supplied {@code request} and returns it.
+     *
+     * <p><strong>Note:</strong> The rules governing how it is
+     * determined whether any given configuration-related object is
+     * "suitable for the supplied {@code request}" are currently
+     * wholly undefined.</p>
+     *
+     * <p>Implementations of this method must not return {@code
+     * null}.</p>
+     *
+     * <p>Implementations of this method must be idempotent.</p>
+     *
+     * <p>Implementations of this method must be safe for concurrent
+     * use by multiple threads.</p>
+     *
+     * <p>Implementations of this method may or may not return a <a
+     * href="doc-files/terminology.html#determinate">determinate</a>
+     * value.</p>
+     *
+     * @param <T> the type of object to load
+     *
+     * @param request the {@link Request} designating the kind of
+     * object to load; must not be {@code null}
+     *
+     * @return the loaded object; never {@code null}
+     *
+     * @exception NoSuchObjectException if the invocation was sound
+     * but the requested object was <a
+     * href="doc-files/terminology.html#absent">absent</a>
+     *
+     * @exception ConfigException if the invocation was sound but the
+     * object could not be loaded for any reason not related to <a
+     * href="doc-files/terminology.html#absent">absence</a>
+     *
+     * @exception IllegalArgumentException if the suplied {@code request}
+     * was invalid for any reason
+     *
+     * @exception NullPointerException if the supplied {@code request}
+     * was {@code null}
+     */
+    public <T> T load(Request<T> request);
+
+    /**
+     * <em>{@linkplain #bootstrap(ClassLoader) Bootstraps}</em> a
+     * {@link Loader} instance for subsequent usage using the
+     * {@linkplain Thread#getContextClassLoader() context
+     * classloader}.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * <p>This method is idempotent.</p>
+     *
+     * <p>This method is safe for concurrent use by multiple
+     * threads.</p>
+     *
+     * <p>This method may or may not return a <a
+     * href="doc-files/terminology.html#determinate">determinate</a>
+     * value. See {@link #bootstrap(ClassLoader)} for details.</p>
+     *
+     * <p>Except as possibly noted above, the observable behavior of
+     * this method is specified to be identical to that of the {@link
+     * #bootstrap(ClassLoader)} method.</p>
+     *
+     * @return a {@link Loader}; never {@code null}
+     *
+     * @exception java.util.ServiceConfigurationError if bootstrapping
+     * failed because of a {@link ServiceLoader#load(Class,
+     * ClassLoader)} or {@link ServiceLoader#findFirst()} problem
+     *
+     * @exception ConfigException if bootstrapping failed because of a
+     * {@link Loader#load(Request)} problem
+     *
+     * @see #bootstrap(ClassLoader)
+     */
+    public static Loader bootstrap() {
+        return bootstrap(Thread.currentThread().getContextClassLoader());
+    }
+
+    /**
+     * <em>Bootstraps</em> a {@link Loader} instance for subsequent
+     * usage.
+     *
+     * <p>The bootstrap process proceeds as follows:</p>
+     *
+     * <ol>
+     *
+     * <li>A <em>primordial {@link Loader}</em> is located with
+     * observable effects equal to those resulting from executing the
+     * following code:
+     *
+     * <blockquote><pre>{@linkplain Loader} loader = {@linkplain ServiceLoader}.{@linkplain ServiceLoader#load(Class, ClassLoader) load(Loader.class, classLoader)}
+     *  .{@linkplain java.util.ServiceLoader#findFirst() findFirst()}
+     *  .{@linkplain java.util.Optional#orElseThrow() orElseThrow}({@linkplain NoSuchObjectException#NoSuchObjectException() NoSuchObjectException::new});</pre></blockquote></li>
+     *
+     * <li>The {@link #load(Request)} method is invoked on the
+     * resulting {@link Loader} with a {@link Request
+     * Request&lt;Loader&gt;} as its sole argument.
+     *
+     * <ul>
+     *
+     * <li>If the invocation throws a {@link NoSuchObjectException},
+     * the primordial {@link Loader} is returned.</li>
+     *
+     * <li>If the invocation returns a {@link Loader}, that {@link
+     * Loader} is returned.</li>
+     *
+     * </ul>
+     *
+     * </li>
+     *
+     * </ol>
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * <p>This method is idempotent.</p>
+     *
+     * <p>This method is safe for concurrent use by multiple
+     * threads.</p>
+     *
+     * <p>This method may or may not return a <a
+     * href="doc-files/terminology.html#determinate">determinate</a>
+     * value depending on the implementation of the {@link Loader}
+     * loaded in step 2 above.</p>
+     *
+     * <p><strong>Note:</strong> The implementation of this method may
+     * change without notice between any two versions of this
+     * specification.  The requirements described above, however, will
+     * be honored in any minor version of this specification within a
+     * given major version.</p>
+     *
+     * @param classLoader the {@link ClassLoader} used to {@linkplain
+     * ServiceLoader#load(Class, ClassLoader) locate service provider
+     * files}; may be {@code null} to indicate the system classloader
+     * (or bootstrap class loader) in accordance with the contract of
+     * the {@link ServiceLoader#load(Class, ClassLoader)} method;
+     * often is the return value of an invocation of {@link
+     * Thread#getContextClassLoader()
+     * Thread.currentThread().getContextClassLoader()}
+     *
+     * @return a {@link Loader}; never {@code null}
+     *
+     * @exception java.util.ServiceConfigurationError if bootstrapping
+     * failed because of a {@link ServiceLoader#load(Class,
+     * ClassLoader)} or {@link ServiceLoader#findFirst()} problem
+     *
+     * @exception ConfigException if bootstrapping failed because of a
+     * {@link Loader#load(Request)} problem
+     */
+    public static Loader bootstrap(ClassLoader classLoader) {
+        Loader loader = ServiceLoader.load(Loader.class, classLoader)
+            .findFirst()
+            .orElseThrow(NoSuchObjectException::new);
+        try {
+            return loader.load(Request.builder(Loader.class).build());
+        } catch (NoSuchObjectException absentValueException) {
+            System.getLogger(Loader.class.getName())
+                .log(System.Logger.Level.DEBUG, absentValueException::getMessage, absentValueException);
+            return loader;
+        }
+    }
+
+    /**
+     * A representation of a <a
+     * href="doc-files/terminology.html#loadrequest">load request</a>
+     * for use by the {@link Loader#load(Request)} method.
+     *
+     * @see #builder(Class)
+     *
+     * @see #builder(TypeToken)
+     *
+     * @see Loader#load(Request)
+     *
+     * @see <a href="doc-files/terminology.html">Terminology</a>
+     */
+    public static interface Request<T> {
+
+        // This is an example of a request qualifier: additional
+        // information that might help to select a *particular* type
+        // of configuration-related object.
+        //
+        // As our use cases come up with more scenarios for
+        // qualifiers, we can evolve them here, rather than adding
+        // overloaded methods to the Loader class itself.
+        /**
+         * Returns a (possibly {@linkplain Optional#isEmpty() empty})
+         * {@link Optional} holding a {@link Locale} used to <a
+         * href="doc-files/terminology.html#qualifier">qualify</a>
+         * this {@link Request}.
+         *
+         * <p>Implementations of this method must not return {@code
+         * null}.</p>
+         *
+         * <p>Implementations of this method must be idempotent.</p>
+         *
+         * <p>Implementations of this method must return a <a
+         * href="doc-files/terminology.html#determinate">determinate</a>
+         * value.</p>
+         *
+         * @return a (possibly {@linkplain Optional#isEmpty() empty})
+         * {@link Optional} holding a {@link Locale} used to <a
+         * href="doc-files/terminology.html#qualifier">qualify</a>
+         * this {@link Request}; never {@code null}
+         */
+        public Optional<Locale> locale();
+
+        // This is an example of a request qualifier: additional
+        // information that might help to select a *particular* type
+        // of configuration-related object.
+        //
+        // As our use cases come up with more scenarios for
+        // qualifiers, we can evolve them here, rather than adding
+        // overloaded methods to the Loader class itself.
+        /**
+         * Returns a (possibly {@linkplain Optional#isEmpty() empty})
+         * {@link Optional} holding a {@link String} representing some
+         * kind of name used to <a
+         * href="doc-files/terminology.html#qualifier">qualify</a>
+         * this {@link Request}.
+         *
+         * <p>Implementations of this method must not return {@code
+         * null}.</p>
+         *
+         * <p>Implementations of this method must be idempotent.</p>
+         *
+         * <p>Implementations of this method must return a <a
+         * href="doc-files/terminology.html#determinate">determinate</a>
+         * value.</p>
+         *
+         * @return a (possibly {@linkplain Optional#isEmpty() empty})
+         * {@link Optional} holding a {@link String} representing some
+         * kind of name used to <a
+         * href="doc-files/terminology.html#qualifier">qualify</a>
+         * this {@link Request}; never {@code null}
+         */
+        public Optional<String> name();
+
+        /**
+         * Returns a {@link TypeToken} modeling the type of object
+         * this {@link Request} is requesting.
+         *
+         * <p>Implementations of this method must not return {@code null}.</p>
+         *
+         * <p>Implementations of this method must be idempotent.</p>
+         *
+         * <p>Implementations of this method must return a <a
+         * href="doc-files/terminology.html#determinate">determinate</a>
+         * value.</p>
+         *
+         * @return a {@link TypeToken}; never {@code null}
+         */
+        public TypeToken<T> type();
+
+        /**
+         * Returns a new {@link Builder}.
+         *
+         * <p>This method never returns {@code null}.</p>
+         *
+         * @param <T> the modeled type
+         *
+         * @param type the type of the {@link Request} that the
+         * returned {@link Builder} will {@linkplain Builder#build()
+         * build}; must not be {@code null}
+         *
+         * @return a new {@link Builder}; never {@code null}
+         *
+         * @exception NullPointerException if {@code type} is {@code
+         * null}
+         *
+         * @exception IllegalArgumentException if the supplied {@link
+         * Class} has type parameters
+         *
+         * @see #builder(TypeToken)
+         *
+         * @see TypeToken#of(Class)
+         */
+        public static <T> Builder<T> builder(final Class<T> type) {
+            return builder(TypeToken.of(type));
+        }
+
+        /**
+         * Returns a new {@link Builder}.
+         *
+         * <p>This method never returns {@code null}.</p>
+         *
+         * @param <T> the modeled type
+         *
+         * @param type the type of the {@link Request} that the
+         * returned {@link Builder} will {@linkplain Builder#build()
+         * build}; must not be {@code null}
+         *
+         * @return a new {@link Builder}; never {@code null}
+         *
+         * @exception NullPointerException if {@code type} is {@code
+         * null}
+         */
+        public static <T> Builder<T> builder(final TypeToken<T> type) {
+            return new Builder<>(type);
+        }
+
+        /**
+         * A builder of {@link Request} objects for use by the {@link
+         * Loader#load(Request)} method.
+         *
+         * @see Request#builder(Class)
+         *
+         * @see Loader#load(Request)
+         *
+         * @see #build()
+         *
+         * @see <a href="doc-files/terminology.html">Terminology</a>
+         */
+        public static final class Builder<T> {
+
+            private Locale locale;
+
+            private String name;
+
+            private final TypeToken<T> type;
+
+            private Builder(final TypeToken<T> type) {
+                super();
+                this.type = Objects.requireNonNull(type, "type");
+            }
+
+            /**
+             * Returns a new {@link Request} implementation.
+             *
+             * <p>This method never returns {@code null}.</p>
+             *
+             * @return a new {@link Request}; never {@code null}
+             *
+             * @see Request
+             */
+            public Request<T> build() {
+                final Optional<Locale> locale = Optional.ofNullable(this.locale);
+                final Optional<String> name = Optional.ofNullable(this.name);
+                return new Request<>() {
+                    @Override
+                    public final Optional<Locale> locale() {
+                        return locale;
+                    }
+                    @Override
+                    public final Optional<String> name() {
+                        return name;
+                    }
+                    @Override
+                    public final TypeToken<T> type() {
+                        return type;
+                    }
+                };
+            }
+
+            /**
+             * Sets this {@link Builder}'s associated {@link Locale}
+             * that will further <a
+             * href="doc-files/terminology.html#qualifier">qualify</a>
+             * any {@link Request}s this {@link Builder} {@linkplain
+             * #build() builds}.
+             *
+             * <p>This method never returns {@code null}.</p>
+             *
+             * <p>This method mutates this {@link Builder}.</p>
+             *
+             * @param locale the {@link Locale}; must not be {@code
+             * null}
+             *
+             * @return this {@link Builder} itself; never {@code null}
+             */
+            public Builder<T> locale(final Locale locale) {
+                this.locale = Objects.requireNonNull(locale, "locale");
+                return this;
+            }
+
+            /**
+             * Sets this {@link Builder}'s associated name that will
+             * further <a
+             * href="doc-files/terminology.html#qualifier">qualify</a>
+             * any {@link Request}s this {@link Builder} {@linkplain
+             * #build() builds}.
+             *
+             * <p>This method never returns {@code null}.</p>
+             *
+             * <p>This method mutates this {@link Builder}.</p>
+             *
+             * @param name the name; must not be {@code null}
+             *
+             * @return this {@link Builder} itself; never {@code null}
+             */
+            public Builder<T> name(final String name) {
+                this.name = Objects.requireNonNull(name, "name");
+                return this;
+            }
+
+        }
+
+    }
+
+}

--- a/api/src/main/java/jakarta/config/NoSuchObjectException.java
+++ b/api/src/main/java/jakarta/config/NoSuchObjectException.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jakarta.config;
+
+/**
+ * A {@link ConfigException} thrown when a configuration-related
+ * object was not found.
+ */
+public class NoSuchObjectException extends ConfigException {
+
+    /**
+     * Creates a new {@link NoSuchObjectException}.
+     */
+    public NoSuchObjectException() {
+        super();
+    }
+
+    /**
+     * Creates a new {@link NoSuchObjectException}.
+     *
+     * @param message a detail message; may be {@code null}
+     */
+    public NoSuchObjectException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new {@link NoSuchObjectException}.
+     *
+     * @param cause the {@link Throwable} responsible for this {@link
+     * NoSuchObjectException}'s existence; may be {@code null}
+     */
+    public NoSuchObjectException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new {@link NoSuchObjectException}.
+     *
+     * @param message a detail message; may be {@code null}
+     *
+     * @param cause the {@link Throwable} responsible for this {@link
+     * NoSuchObjectException}'s existence; may be {@code null}
+     */
+    public NoSuchObjectException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/api/src/main/java/jakarta/config/TypeToken.java
+++ b/api/src/main/java/jakarta/config/TypeToken.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jakarta.config;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+
+import java.util.Objects;
+
+/**
+ * A holder of a modeled {@link Type} that embodies <a
+ * href="http://gafter.blogspot.com/2006/12/super-type-tokens.html"
+ * target="_parent">Gafter's gadget</a>.
+ *
+ * <p>To use this class, create a new instance of an anonymous
+ * subclass of it, and then call {@link #type() type()} on it.  For
+ * example:</p>
+ *
+ * <blockquote><pre>
+ * // type will be a {@linkplain ParameterizedType} whose {@linkplain ParameterizedType#getRawType() rawType} is {@linkplain java.util.List List.class} and
+ * // whose {@linkplain ParameterizedType#getActualTypeArguments() sole type argument} is {@linkplain String String.class}
+ * {@linkplain Type} type = new {@linkplain TypeToken TypeToken}&lt;{@linkplain java.util.List List}&lt;{@linkplain String}&gt;&gt;() {}.{@linkplain #type() type()};
+ * assert type instanceof {@linkplain ParameterizedType};
+ * assert (({@linkplain ParameterizedType})type).{@linkplain ParameterizedType#getRawType() getRawType()} == {@linkplain java.util.List List.class};
+ * assert (({@linkplain ParameterizedType})type).{@linkplain ParameterizedType#getActualTypeArguments() getActualTypeArguments()}[0] == {@linkplain String String.class};</pre></blockquote>
+ *
+ * @param <T> the modeled type; often {@linkplain ParameterizedType
+ * parameterized}
+ *
+ * @see #type()
+ */
+public abstract class TypeToken<T> {
+
+
+    /*
+     * Instance fields.
+     */
+
+
+    private final Type type;
+
+
+    /*
+     * Constructors.
+     */
+
+
+    /**
+     * Creates a new {@link TypeToken}.
+     */
+    protected TypeToken() {
+        super();
+        this.type = mostSpecializedParameterizedSuperclass(this.getClass()).getActualTypeArguments()[0];
+    }
+
+    private TypeToken(final Type t) {
+        super();
+        this.type = Objects.requireNonNull(t, "t");
+    }
+
+
+    /*
+     * Instance methods.
+     */
+
+
+    /**
+     * Returns the {@link Type} modeled by this {@link TypeToken}.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * <p>This method produces a <a
+     * href="doc-files/terminology.html#determinate">determinate</a>
+     * value.</p>
+     *
+     * <p>This method is idempotent.</p>
+     *
+     * <p>This method is safe for concurrent use by multiple
+     * threads.</p>
+     *
+     * @return the {@link Type} modeled by this {@link TypeToken};
+     * never {@code null}
+     */
+    public final Type type() {
+        return this.type;
+    }
+
+    /**
+     * Returns the {@linkplain #erase(Type) type erasure} of this {@link
+     * TypeToken}'s {@linkplain #type() modeled <code>Type</code>}, or
+     * {@code null} if erasing the {@link Type} would result in a
+     * non-{@link Class} erasure (in which case the erasure is simply
+     * the {@link Type} itself), or if an erasure cannot be determined.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * <p>This method produces a <a
+     * href="doc-files/terminology.html#determinate">determinate</a>
+     * value.</p>
+     *
+     * <p>This method is idempotent.</p>
+     *
+     * <p>This method is safe for concurrent use by multiple
+     * threads.</p>
+     *
+     * @return the {@linkplain #erase(Type) type erasure} of this {@link
+     * TypeToken}'s {@linkplain #type() modeled <code>Type</code>}, or
+     * {@code null} if erasing the {@link Type} would result in a
+     * non-{@link Class} erasure, or if an erasure cannot be determined
+     */
+    public final Class<?> erase() {
+        return erase(this.type());
+    }
+
+    /**
+     * Returns a hashcode for this {@link TypeToken} computed from the
+     * {@link Type} it {@linkplain #type() models}.
+     *
+     * <p>This method produces a <a
+     * href="doc-files/terminology.html#determinate">determinate</a>
+     * value.</p>
+     *
+     * <p>This method is idempotent.</p>
+     *
+     * <p>This method is safe for concurrent use by multiple
+     * threads.</p>
+     *
+     * @return a hashcode for this {@link TypeToken}
+     *
+     * @see #equals(Object)
+     */
+    @Override // Object
+    public int hashCode() {
+        Type type = this.type();
+        return type == null ? 0 : type.hashCode();
+    }
+
+    /**
+     * Returns {@code true} if the supplied {@link Object} is equal to
+     * this {@link TypeToken}.
+     *
+     * <p>This method returns {@code true} if the supplied {@link
+     * Object}'s {@linkplain Object#getClass() class} is this {@link
+     * TypeToken}'s class and if its {@linkplain #type() modeled
+     * <code>Type</code>} is equal to this {@link TypeToken}'s
+     * {@linkplain #type() modeled <code>Type</code>}.</p>
+     *
+     * <p>This method produces a <a
+     * href="doc-files/terminology.html#determinate">determinate</a>
+     * value.</p>
+     *
+     * <p>This method is idempotent.</p>
+     *
+     * <p>This method is safe for concurrent use by multiple
+     * threads.</p>
+     *
+     * @param other the {@link Object} to test; may be {@code null} in
+     * which case {@code false} will be returned
+     *
+     * @return {@code true} if the supplied {@link Object} is equal to
+     * this {@link TypeToken}; {@code false} otherwise
+     *
+     * @see #hashCode()
+     */
+    @Override // Object
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        } else if (other instanceof TypeToken<?>) {
+            return Objects.equals(this.type(), ((TypeToken<?>)other).type());
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Returns a {@link String} representation of this {@link
+     * TypeToken}.
+     *
+     * <p>This method returns a value equal to that returned by {@link
+     * Type#getTypeName() this.type().getTypeName()}.</p>
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * <p>This method produces a <a
+     * href="doc-files/terminology.html#determinate">determinate</a>
+     * value.</p>
+     *
+     * <p>This method is idempotent.</p>
+     *
+     * <p>This method is safe for concurrent use by multiple
+     * threads.</p>
+     *
+     * @return a {@link String} representation of this {@link
+     * TypeToken}; never {@code null}
+     */
+    @Override // Object
+    public String toString() {
+        Type type = this.type();
+        return type == null ? "null" : type.getTypeName();
+    }
+
+    /**
+     * Returns the type erasure for the supplied {@link Type} according
+     * to <a
+     * href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.6"
+     * target="_parent">the rules of the Java Language
+     * Specification, section 4.6</a>.
+     *
+     * <ul>
+     *
+     * <li>If {@code null} is supplied, {@code null} is returned.</li>
+     *
+     * <li>If a {@link Class} is supplied, the {@link Class} is
+     * returned.</li>
+     *
+     * <li>If a {@link ParameterizedType} is supplied, the result of
+     * invoking {@link #erase(Type)} on its {@linkplain
+     * ParameterizedType#getRawType() raw type} is returned.</li>
+     *
+     * <li>If a {@link GenericArrayType} is supplied, the result of
+     * invoking {@link Object#getClass()} on an invocation of {@link
+     * java.lang.reflect.Array#newInstance(Class, int)} with the return
+     * value of an invocation of {@link #erase(Type)} on its {@linkplain
+     * GenericArrayType#getGenericComponentType() generic component
+     * type} and {@code 0} as its arguments is returned.</li>
+     *
+     * <li>If a {@link TypeVariable} is supplied, the result of invoking
+     * {@link #erase(Type)} <strong>on its {@linkplain
+     * TypeVariable#getBounds() first (leftmost) bound}</strong> is
+     * returned (if it has one) or {@link Object Object.class} if it
+     * does not.  <strong>Any other bounds are ignored.</strong></li>
+     *
+     * <li>If a {@link WildcardType} is supplied, the result of invoking
+     * {@link #erase(Type)} <strong>on its {@linkplain
+     * WildcardType#getUpperBounds() first upper bound}</strong> is
+     * returned.  <strong>Any other bounds are ignored.</strong></li>
+     *
+     * <li>If any other {@link Type} implementation is supplied, {@code
+     * null} is returned.</li>
+     *
+     * </ul>
+     *
+     * <p>This method may return {@code null}.</p>
+     *
+     * <p>This method produces a <a
+     * href="doc-files/terminology.html#determinate">determinate</a>
+     * value.</p>
+     *
+     * <p>This method is idempotent.</p>
+     *
+     * <p>This method is safe for concurrent use by multiple
+     * threads.</p>
+     *
+     * @param type the {@link Type} for which the corresponding type
+     * erasure is to be returned; may be {@code null} in which case
+     * {@code null} will be returned
+     *
+     * @return a {@link Class}, or {@code null} if a suitable {@link
+     * Class}-typed type erasure could not be determined, indicating
+     * that the type erasure is the supplied {@link Type} itself
+     */
+    private static final Class<?> erase(Type type) {
+        // https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.6
+        // 4.6. Type Erasure
+        //
+        // Type erasure is a mapping from types (possibly including
+        // parameterized types and type variables) to types (that are
+        // never parameterized types or type variables). We write |T|
+        // for the erasure of type T. The erasure mapping is defined
+        // as follows:
+        //
+        // The erasure of a parameterized type (§4.5) G<T1,…,Tn> is
+        // |G|.
+        //
+        // The erasure of a nested type T.C is |T|.C.
+        //
+        // The erasure of an array type T[] is |T|[].
+        //
+        // The erasure of a type variable (§4.4) is the erasure of its
+        // leftmost bound.
+        //
+        // The erasure of every other type is the type itself.
+        if (type == null) {
+            return null;
+        } else if (type instanceof Class<?>) {
+            return erase((Class<?>)type);
+        } else if (type instanceof ParameterizedType) {
+            return erase((ParameterizedType)type);
+        } else if (type instanceof GenericArrayType) {
+            return erase((GenericArrayType)type);
+        } else if (type instanceof TypeVariable<?>) {
+            return erase((TypeVariable<?>)type);
+        } else if (type instanceof WildcardType) {
+            return erase((WildcardType)type);
+        } else {
+            return null;
+        }
+    }
+
+    private static final Class<?> erase(Class<?> type) {
+        // https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.6
+        // …
+        // The erasure of a nested type T.C is
+        // |T|.C. [Class.getDeclaringClass() returns an already erased
+        // type.]
+        //
+        // The erasure of an array type T[] is |T|[]. [A Class that is
+        // an array has a Class as its component type, and that is
+        // already erased.]
+        // …
+        // The erasure of every other type is the type itself. [So in all
+        // cases we can just return the supplied Class<?>.]
+        return type;
+    }
+
+    private static final Class<?> erase(ParameterizedType type) {
+        // https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.6
+        // …
+        // The erasure of a parameterized type (§4.5) G<T1,…,Tₙ> is
+        // |G| [|G| means the erasure of G, i.e. the erasure of
+        // type.getRawType()].
+        return erase(type.getRawType());
+    }
+
+    private static final Class<?> erase(GenericArrayType type) {
+        // https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.6
+        //
+        // The erasure of an array type T[] is |T|[]. [|T| means the
+        // erasure of T. We erase the genericComponentType() and use
+        // Class#arrayType() to find the "normal" array class for the
+        // erasure.]
+        Class<?> componentType = erase(type.getGenericComponentType());
+        if (componentType == null) {
+            return null;
+        } else {
+            // Needs Java 17
+            // return componentType.arrayType();
+
+            // (Java 17's Class#arrayType() does exactly this behind the scenes.)
+            return Array.newInstance(componentType, 0).getClass();
+        }
+    }
+
+    private static final Class<?> erase(TypeVariable<?> type) {
+        // https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.6
+        //
+        // The erasure of a type variable (§4.4) is the erasure of its
+        // leftmost bound. [In the case of a TypeVariable<?> that
+        // returns multiple bounds, we know they will start with a
+        // class, not an interface and not a type variable.]
+        Type[] bounds = type.getBounds();
+        return bounds.length > 0 ? erase(bounds[0]) : Object.class;
+    }
+
+    private static final Class<?> erase(WildcardType type) {
+        // https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.6
+        //
+        // The erasure of a type variable (§4.4) is the erasure of its
+        // leftmost bound.  [WildcardTypes aren't really in the JLS
+        // per se but they behave like type variables. Only upper
+        // bounds will matter here.]
+        Type[] bounds = type.getUpperBounds();
+        return bounds != null && bounds.length > 0 ? erase(bounds[0]) : Object.class;
+    }
+
+
+    /*
+     * Static methods.
+     */
+
+
+    /**
+     * Returns a new {@link TypeToken} representing the supplied
+     * <strong>non-generic</strong> {@link Class}.
+     *
+     * <p>This method never returns {@code null}.</p>
+     *
+     * <p>This method is safe for concurrent use by multiple
+     * threads.</p>
+     *
+     * @param <T> the modeled type
+     *
+     * @param c the <strong>non-generic</strong> class in question;
+     * must not be {@code null}; must return a zero-length array from
+     * any invocation of its {@link Class#getTypeParameters()} method
+     *
+     * @return a new {@link TypeToken}; never {@code null}
+     *
+     * @exception NullPointerException if {@code c} is {@code null}
+     *
+     * @exception IllegalArgumentException if {@code c} is a generic
+     * {@link Class}
+     */
+    public static final <T> TypeToken<T> of(final Class<T> c) {
+        if (c.getTypeParameters().length > 0) {
+            throw new IllegalArgumentException();
+        }
+        return new TypeToken<>(c) {};
+    }
+
+    private static final ParameterizedType mostSpecializedParameterizedSuperclass(Type type) {
+        if (type == null || type == Object.class || type == TypeToken.class) {
+            return null;
+        } else {
+            Class<?> erasure = erase(type);
+            if (erasure == null || erasure == Object.class || !(TypeToken.class.isAssignableFrom(erasure))) {
+                return null;
+            } else if (type instanceof ParameterizedType) {
+                return (ParameterizedType)type;
+            } else {
+                return mostSpecializedParameterizedSuperclass(erasure.getGenericSuperclass());
+            }
+        }
+    }
+
+}

--- a/api/src/main/javadoc/jakarta.config.api/jakarta/config/doc-files/terminology.html
+++ b/api/src/main/javadoc/jakarta.config.api/jakarta/config/doc-files/terminology.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+    <title>Terminology</title>
+  </head>
+  <body>
+    <h1>Terminology</h1>
+    <dl>
+
+      <dt><a name="absent">Absent</a></dt>
+
+      <dd>Describes a method invocation's return value as being
+        missing.  An absent return value is often, but not always,
+        represented by <code>null</code>,
+        an <a href="https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/util/Optional.html#empty()">empty <code>Optional</code></a>,
+        or the throwing of
+        an <a href="../NoSuchObjectException.html">appropriate
+        exception</a>.  The opposite of an <em>absent</em> value is
+        a <a href="#present"><em>present</em></a> value.</dd>
+
+      <dt><a name="determinate">Determinate</a></dt>
+
+      <dd>Describes a method invocation's return value as being wholly
+        determined by the invocation's arguments, <em>i.e.</em>  if
+        the method is invoked with the same arguments multiple times,
+        each such invocation will return a value that is equal to the
+        return value of any other invocation with arguments equal to
+        the invocation's arguments.  A method invocation's return
+        value that is not wholly determined by the invocation's
+        arguments is said to be <em>indeterminate</em>.</dd>
+
+      <dt><a name="load">Load</a></dt>
+
+      <dd>To <a href="#selection"><em>select</em></a> and instantiate
+        exactly one <a href="#present"><em>present</em></a> and
+        maximally <a href="#suitability"><em>suitable</em></a>
+        configuration-related object for a given load request.</dd>
+
+      <dt><a name="loadrequest">Load Request</a></dt>
+
+      <dd>A notional request to <a href="#load"><em>load</em></a> a
+        (<a href="#suiability"><em>suitable</em></a>
+        and <a href="#present"><em>present</em></a>)
+        configuration-related object.</dd>
+
+      <dt><a name="present">Present</a></dt>
+
+      <dd>Describes a method invocation's return value as existing.
+        The opposite of a <em>present</em> value is
+        an <a href="#absent"><em>absent</em></a> value.</dd>
+
+      <dt><a name="qualifier">Qualifier</a></dt>
+
+      <dd>Extra immutable information that further clarifies or
+        specifies a <a href="#loadrequest"><em>load
+        request</em></a>.</dd>
+
+      <dt><a name="selection">Selection</a></dt>
+
+      <dd>The process of choosing a (<a href="#present"><em>present</em></a>)
+        configuration-related object that is more, or
+        less, <a href="#suitability"><em>suitable</em></a> for a given
+        <a href="#loadrequest"><em>load request</em></a>.</dd>
+
+      <dt><a name="suitability">Suitability</a></dt>
+
+      <dd>The property that any given configuration-related object has
+        that describes its fitness for a
+        given <a href="#loadrequest"><em>load request</em></a>.  The
+        process of finding a suitable configuration-related object for
+        a given load request is known
+        as <a href="#selection"><em>selection</em></a>.  Any given
+        configuration-related object may be more or less suitable than
+        another for any given load request.</dd>
+
+    </dl>
+  </body>
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -179,7 +179,7 @@
                         <release>${version.java}</release>
                         <forceJavacCompilerUse>true</forceJavacCompilerUse>
                         <compilerArgs>
-                            <arg>-Xlint:unchecked</arg>
+                            <arg>-Xlint:all</arg>
                             <!--
                             https://issues.apache.org/jira/browse/MCOMPILER-368
                              -->


### PR DESCRIPTION
**Don't dive into the code without reading this description and understanding it, or without reading and understanding the javadocs.**

This pull request is number two of three **mutually exclusive** options. It sketches a "loader" API for loading configuration-related objects in some vague unspecified manner. This pull request is named **Option 2**.  You may also be interested in **Option 1** (#131) and **Option 3** (#133).

Sample usage:
```
Loader loader = loader.bootstrap();
MyConfigurationRelatedObject object = null;
try {
    object = loader.load(Request.builder(MyConfigurationRelatedObject.class).build());
} catch (NoSuchObjectException e) {
    // object is absent
}
```

In as many cases as I could, I asked for and incorporated some group opinions while working this sketch up. See for example #75, #109, #110, #119, #122 (particularly [my comment](https://github.com/eclipse-ee4j/config/discussions/122#discussioncomment-3916482) and Roberto's response), #124, and #127, among others.

**Option 2** (this PR) differs from **Option 1** (#131) primarily by modeling the "loader API" with an explicit `Request` object as its sole parameter.  This provides a place where evolution of what it means to request an object can proceed with minimal damage to the actual loader API itself (the `Request` interface changes, the `load` method does not).  The `Request` comes with an associated `Builder`; I've sketched one or two additional qualifiers to show what "extra" information might look like.  (If you're honed in on the details, you're reading too closely as it is _way_ too early for that kind of thing.)

In **Option 2** (this PR), as in **Option 1** (#131), the `Loader` returns the loaded object directly. Following the group consensus arrived at in #119 (see [Dmitry's comment](https://github.com/eclipse-ee4j/config/discussions/119#discussioncomment-3715279) in particular), whether or not the return value is _determinate_ is deliberately left unspecified.

I personally prefer **Option 3** (#133) which, IMHO, allows for more graceful API evolution over time.

**Finally, and perhaps most importantly, I still think it is _far_ too early for PRs** and I would prefer to write documents first, but to date that has not met with success. Therefore I hope this (and the other options) will at least get the discussion going.

Signed-off-by: Laird Nelson <ljnelson@gmail.com>