### PR TITLE
Alter Configuration draft PR with Single String path and String path separator

### DIFF
--- a/api/src/main/java/jakarta/config/Configuration.java
+++ b/api/src/main/java/jakarta/config/Configuration.java
@@ -25,10 +25,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that the annotated class is a <em>configuration class</em>, as defined in the Jakarta Config specification.
+ * <p> This annotation is to mark an interface to contain configurations. The configurations will be injected
+ * by the implementation of Jakarta Config.</p>
  *
- * <p><strong>\u26A0 Caution:</strong> you are reading an incomplete draft specification that is subject to
- * change.</p>
+ * <p>The <em>configuration interface</em> is resolved with portion of application's
+ * <em>persistent configuration</em> identified by <em>configuration path</em>.
+ *
+ * <p>The terms <em>configuration interface</em>, <em>configuration key</em>, <em>configuration path</em>, <em>canonical
+ * representation</em>, <em>persistent configuration</em>, <em>resolve</em>, and others are used here as defined in
+ * the Jakarta Config specification.</p>
+
+ * <p><strong>\u26A0 Caution:</strong> you are reading an incomplete draft specification that is subject to change.</p>
  */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
@@ -36,36 +43,34 @@ import java.lang.annotation.Target;
 public @interface Configuration {
 
     /**
-     * An array of <em>configuration keys</em>, forming a <em>configuration path</em>, that may identify where, in a
-     * given application's <em>persistent configuration</em>, the configuration relevant for the annotated configuration
-     * class may be found.
+     * The <em>configuration path</em> may identify where, in a given application's <em>persistent configuration</em>,
+     * the configuration relevant for the annotated configuration class may be found.
      *
-     * <p>Each configuration key in the array forming this element is a <em>canonical representation</em> of a
-     * configuration key, as defined in the Jakarta Config specification.</p>
+     * <p>The configuration path is a <em>canonical representation</em> of a <em>configuration key</em>,
+     * as defined in the Jakarta Config specification.</p>
      *
-     * <p>The configuration path represented by this element is effectively a hint to a Jakarta Config implementation
-     * about where, in an application's persistent configuration, a portion of that configuration relevant to the
-     * annotated configuration class may be found.  Because a Java class may be used in many different applications, and
-     * because those applications may have very different persistent configurations, the configuration path represented
-     * by this element cannot be regarded as authoritative for all possible applications. Rather, it is a useful
-     * default, and Jakarta Config implementations should permit it to be overridden <strong>in ways that are currently
-     * undefined</strong>.</p>
+     * <p>For instance, should the <em>persistent configuration</em> contain
+     * <pre>  my.configuration.user=tester</pre>
+     * the <em>configuration key</em> for configuration portion {@code user=tester} would be the prefix {@code my.configuration}.
+     * The <em>canonical representation</em> (configuration path) of this configuration key using
+     * the default configuration path separator of {@code .} (dot) would be {@code my.configuration} as well,
+     * while the <em>canonical representation</em> (path) of this configuration key using
+     * the {@code /} (slash) separator would be {@code my/configuration}.
+     * </p>
      *
-     * <p>There is no requirement that the configuration path represented by this element must resolve in any given
-     * application, since it may be ignored in favor of an application-specific override. On the other hand, in simple
-     * applications where it is known that a configuration class will not be reused elsewhere, the configuration path
-     * represented by this element may indeed resolve.</p>
-     *
-     * <p>Jakarta Config implementations must consider namespace concerns <strong>in ways that are yet to be
-     * defined</strong> when reading the value of this element.</p>
-     *
-     * <p>The terms <em>configuration class</em>, <em>configuration key</em>, <em>configuration path</em>, <em>canonical
-     * representation</em>, <em>persistent configuration</em>, <em>resolve</em>, and others are used here as defined in
-     * the Jakarta Config specification.</p>
-     *
-     * @return an array of {@link String}s, each of which is a canonical representation of a configuration key, forming
-     * a representation of a configuration path
+     * @return a {@link String} representation of a configuration path.
      */
-    String[] path() default {};
+    String path() default "";
+
+
+    /**
+     * The <em>separator</em> used in the <em>configuration path</em> to identify the relevant <em>configuration key</em>
+     * in application's <em>persistent configuration</em>.
+     *
+     * <p>The default separator is <em>.</em> (dot) symbol.</p>
+     *
+     * @return a {@link String} representation of a configuration path separator.
+     */
+    String separator() default ".";
 
 }

--- a/api/src/main/java/jakarta/config/Configuration.java
+++ b/api/src/main/java/jakarta/config/Configuration.java
@@ -25,13 +25,47 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * <p>
- *     The annotation to be used to mark the interface to be handled by the injection support.
- * </p>
+ * Indicates that the annotated class is a <em>configuration class</em>, as defined in the Jakarta Config specification.
+ *
+ * <p><strong>\u26A0 Caution:</strong> you are reading an incomplete draft specification that is subject to
+ * change.</p>
  */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Configuration {
+
+    /**
+     * An array of <em>configuration keys</em>, forming a <em>configuration path</em>, that may identify where, in a
+     * given application's <em>persistent configuration</em>, the configuration relevant for the annotated configuration
+     * class may be found.
+     *
+     * <p>Each configuration key in the array forming this element is a <em>canonical representation</em> of a
+     * configuration key, as defined in the Jakarta Config specification.</p>
+     *
+     * <p>The configuration path represented by this element is effectively a hint to a Jakarta Config implementation
+     * about where, in an application's persistent configuration, a portion of that configuration relevant to the
+     * annotated configuration class may be found.  Because a Java class may be used in many different applications, and
+     * because those applications may have very different persistent configurations, the configuration path represented
+     * by this element cannot be regarded as authoritative for all possible applications. Rather, it is a useful
+     * default, and Jakarta Config implementations should permit it to be overridden <strong>in ways that are currently
+     * undefined</strong>.</p>
+     *
+     * <p>There is no requirement that the configuration path represented by this element must resolve in any given
+     * application, since it may be ignored in favor of an application-specific override. On the other hand, in simple
+     * applications where it is known that a configuration class will not be reused elsewhere, the configuration path
+     * represented by this element may indeed resolve.</p>
+     *
+     * <p>Jakarta Config implementations must consider namespace concerns <strong>in ways that are yet to be
+     * defined</strong> when reading the value of this element.</p>
+     *
+     * <p>The terms <em>configuration class</em>, <em>configuration key</em>, <em>configuration path</em>, <em>canonical
+     * representation</em>, <em>persistent configuration</em>, <em>resolve</em>, and others are used here as defined in
+     * the Jakarta Config specification.</p>
+     *
+     * @return an array of {@link String}s, each of which is a canonical representation of a configuration key, forming
+     * a representation of a configuration path
+     */
+    String[] path() default {};
 
 }


### PR DESCRIPTION
Redesigned `Configuration` path and a separator from the original @ljnelson draft PR.